### PR TITLE
GFF Reader - fix type of returned VOID fields

### DIFF
--- a/src/nwn/gff/_reader.py
+++ b/src/nwn/gff/_reader.py
@@ -7,6 +7,7 @@ from nwn.gff._types import (
     CExoString,
     ResRef,
     CExoLocString,
+    VOID,
     Struct,
     List,
     SIMPLE_TYPES,
@@ -113,7 +114,7 @@ def read(file: BinaryIO):
 
         if field.type == FieldKind.VOID:
             sz = struct.unpack("<I", file.read(4))[0]
-            return file.read(sz)
+            return VOID(file.read(sz))
 
         if field.type == FieldKind.LIST:
             offset = field.data_or_offset // 4


### PR DESCRIPTION
I've added the missing import for the VOID class, and wrapped the raw binary before returning the value.
This fixes the issue of the value being an instance of the native `bytes` class, which required special handling in downstream tools.

Let me know if the fix is insufficient and requires additional edits