### PR TITLE
ERF Reader - fix handling of file objects passed to the add_file method

### DIFF
--- a/src/nwn/erf.py
+++ b/src/nwn/erf.py
@@ -4,6 +4,7 @@ import struct
 from typing import NamedTuple, BinaryIO
 from enum import Enum
 from datetime import date, timedelta
+from io import FileIO, BufferedReader
 
 from ._shared import (
     get_nwn_encoding,
@@ -217,7 +218,7 @@ class Writer:
         self._locstr[gendered_lang] = text
 
     def add_file(self, filename: str, data: bytes | BinaryIO):
-        if isinstance(data, BinaryIO):
+        if isinstance(data, (FileIO, BufferedReader)):
             data = data.read()
 
         offset = self._file.tell()


### PR DESCRIPTION
The snippet in the method implementation that fetches the binary content of the file object never triggers because of the mismatched type in the isinstance() conditional check. As a result, the len() check that follows errors out due to the data not being of type `bytes`.
By checking against the specific type returned by the type() function, the snippet does what is meant to do.

Let me know if there is the need for a more sophisticated fix, or if I'm misunderstanding the issue altogether.